### PR TITLE
use `determinate` instead of `flakehub` as an action input

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
         with:
-          flakehub: true
+          determinate: true
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: webfactory/ssh-agent@v0.9.0
         if: ${{ inputs.enable-ssh-agent }}


### PR DESCRIPTION
... just to avoid confusion, since `flakehub` is listed as deprecated for [DeterminateSystems/nix-installer-action@main](https://github.com/DeterminateSystems/nix-installer-action)

So this is really just to bring the code in line with the docs.