### PR TITLE
add linux arm runner

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,7 +24,8 @@ on:
             "aarch64-darwin": "macos-latest",
             "x86_64-darwin": "macos-latest",
             "x86_64-linux": "ubuntu-latest",
-            "i686-linux": "ubuntu-latest"
+            "i686-linux": "ubuntu-latest",
+            "aarch64-linux": "ubuntu-24.04-arm"
           }
     outputs:
       flake_name:


### PR DESCRIPTION
Linux Arm64 runners are [now available on GitHub Actions](https://github.blog/news-insights/product-news/arm64-on-github-actions-powering-faster-more-efficient-build-systems/) (albeit in preview).