### PR TITLE
pass through `fail-fast` option

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: "."
         type: string
+      fail-fast:
+        required: false
+        default: true
+        type: boolean
+        description: "Whether to cancel all in-progress jobs if any matrix job fails"
       runner-map:
         required: false
         type: string
@@ -93,6 +98,7 @@ jobs:
     runs-on: ${{ matrix.systems.runner }}
     needs: inventory
     strategy:
+      fail-fast: ${{ inputs.fail-fast }}
       matrix:
         systems: ${{ fromJSON(needs.inventory.outputs.systems) }}
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,22 @@ jobs:
       ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 ```
 
+#### Continue on failure
+
+By default, if any build in the matrix fails, the workflow will cancel all remaining in-progress jobs.
+You can change this behavior by setting `fail-fast` to `false`:
+
+```yaml
+jobs:
+  DeterminateCI:
+    uses: DeterminateSystems/ci/.github/workflows/workflow.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      fail-fast: false
+```
+
 ## Notes
 
 This workflow uses a collection of GitHub Actions by Determinate Systems, all of which are covered by the Determinate Systems [privacy policy][privacy] and [terms of service][tos].


### PR DESCRIPTION
I sometimes like to be able to let the run complete *all* `systems = []` for debugging purposes.