### PR TITLE
explain non-standard runners and revert linux-arm default

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -25,7 +25,7 @@ on:
             "x86_64-darwin": "macos-latest",
             "x86_64-linux": "ubuntu-latest",
             "i686-linux": "ubuntu-latest",
-            "aarch64-linux": "ubuntu-24.04-arm"
+            "aarch64-linux": "ubuntu-latest"
           }
     outputs:
       flake_name:

--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ ERROR magic_nix_cache: FlakeHub cache initialization failed: FlakeHub cache erro
 
 By default, the CI maps the Nix systems to their equivalent GitHub-hosted runners:
 
-|  | macOS (Apple Silicon) | ARM Linux | macOS (Intel) | x86 Linux |
-|---|---|---|---|---|
-| Flake `system:` (Nix build platform) | `aarch64-darwin` | `aarch64-linux` | `x86_64-darwin` | `x86_64-linux` |
+|                                                   | macOS (Apple Silicon)                | ARM Linux                   | macOS (Intel)                        | x86 Linux                   |
+| ------------------------------------------------- | ------------------------------------ | --------------------------- | ------------------------------------ | --------------------------- |
+| Flake `system:` (Nix build platform)              | `aarch64-darwin`                     | `aarch64-linux`             | `x86_64-darwin`                      | `x86_64-linux`              |
 | [GitHub Actions Runner][runners] (workflow label) | `macos-latest` (using Apple Silicon) | `ubuntu-latest` (using x86) | `macos-latest` (using Apple Silicon) | `ubuntu-latest` (using x86) |
 
 > [!INFO]
@@ -135,7 +135,7 @@ jobs:
 ```
 
 > [!TIP]
-> Using `macos-latest-large` is currently the only way to run *current* macOS on Intel architecture.
+> Using `macos-latest-large` is currently the only way to run _current_ macOS on Intel architecture.
 
 The other two types of runners are those provisioned on your own infrastructure, and [larger Ubuntu (not macOS) runners][runners-large] with bespoke specs (for example, 64 CPUs, 128GB RAM) hosted by GitHub.
 Confusingly, GitHub sometimes refers to both of these as "self-hosted" runners.

--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ Confusingly, GitHub sometimes refers to both of these as "self-hosted" runners.
 >
 > ```diff
 > jobs:
->  DeterminateCI:
-> - uses: DeterminateSystems/ci/.github/workflows/workflow.yml@main
-> + uses: $YOURORG/ci/.github/workflows/workflow.yml@main
+>   DeterminateCI:
+> -    uses: DeterminateSystems/ci/.github/workflows/workflow.yml@main
+> +    uses: $YOURORG/ci/.github/workflows/workflow.yml@main
 > ```
 >
 > Replace `$YOURORG` with your own organisation or user.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ By default, the CI maps the Nix systems to their equivalent GitHub-hosted runner
 ##### Non-standard runners
 
 You can also use several types of non-standard runners by providing a custom runner map.
-
 For example, this runner map enables the [larger GitHub runners for macOS][runners-large-macos]:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ By default, the CI maps the Nix systems to their equivalent GitHub-hosted runner
 
 |                                                   | macOS (Apple Silicon)                | ARM Linux                   | macOS (Intel)                        | x86 Linux                   |
 | ------------------------------------------------- | ------------------------------------ | --------------------------- | ------------------------------------ | --------------------------- |
-| Flake `system:` (Nix build platform)              | `aarch64-darwin`                     | `aarch64-linux`             | `x86_64-darwin`                      | `x86_64-linux`              |
+| Flake `system` (Nix build platform)              | `aarch64-darwin`                     | `aarch64-linux`             | `x86_64-darwin`                      | `x86_64-linux`              |
 | [GitHub Actions Runner][runners] (workflow label) | `macos-latest` (using Apple Silicon) | `ubuntu-latest` (using x86) | `macos-latest` (using Apple Silicon) | `ubuntu-latest` (using x86) |
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ By default, the CI maps the Nix systems to their equivalent GitHub-hosted runner
 
 |                                                   | macOS (Apple Silicon)                | ARM Linux                   | macOS (Intel)                        | x86 Linux                   |
 | ------------------------------------------------- | ------------------------------------ | --------------------------- | ------------------------------------ | --------------------------- |
-| Flake `system` (Nix build platform) | `aarch64-darwin` | `aarch64-linux` | `x86_64-darwin` | `x86_64-linux`
+| Flake `system:` (Nix build platform) | `aarch64-darwin` | `aarch64-linux` | `x86_64-darwin` | `x86_64-linux`
 | [GitHub Actions Runner][runners] (workflow label) | `macos-latest` (using Apple Silicon) | `ubuntu-latest` (using x86) | `macos-latest` (using Apple Silicon) | `ubuntu-latest` (using x86) |
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -99,25 +99,25 @@ ERROR magic_nix_cache: FlakeHub cache initialization failed: FlakeHub cache erro
 
 #### GitHub Actions Runners
 
-##### Standard & larger runners
+##### Standard and larger runners
 
 By default, the CI maps the Nix systems to their equivalent GitHub-hosted runners:
 
 |                                                   | macOS (Apple Silicon)                | ARM Linux                   | macOS (Intel)                        | x86 Linux                   |
 | ------------------------------------------------- | ------------------------------------ | --------------------------- | ------------------------------------ | --------------------------- |
-| Flake `system:` (Nix build platform)              | `aarch64-darwin`                     | `aarch64-linux`             | `x86_64-darwin`                      | `x86_64-linux`              |
+| Flake `system` (Nix build platform) | `aarch64-darwin` | `aarch64-linux` | `x86_64-darwin` | `x86_64-linux`
 | [GitHub Actions Runner][runners] (workflow label) | `macos-latest` (using Apple Silicon) | `ubuntu-latest` (using x86) | `macos-latest` (using Apple Silicon) | `ubuntu-latest` (using x86) |
 
-> [!INFO]
+> [!NOTE]
 > There is also a [standard ARM Linux runner][runners-linux-arm] `ubuntu-24.04-arm`, currently in public preview and only supported on public repositories.
 > To use it, supply your own runner map as shown below.
-> To use ARM Linux runners on private repositories, you need a non-standard runners, as shown below.
+> To use ARM Linux runners on private repositories, you need non-standard runners, as shown below.
 
-##### Non-Standard runners
+##### Non-standard runners
 
 You can also use several types of non-standard runners by providing a custom runner map.
 
-For example, this runner-map enables the [larger GitHub runners for macOS][runners-large-macos]:
+For example, this runner map enables the [larger GitHub runners for macOS][runners-large-macos]:
 
 ```yaml
 jobs:

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ By default, the CI maps the Nix systems to their equivalent GitHub-hosted runner
 
 |                                                   | macOS (Apple Silicon)                | ARM Linux                   | macOS (Intel)                        | x86 Linux                   |
 | ------------------------------------------------- | ------------------------------------ | --------------------------- | ------------------------------------ | --------------------------- |
-| Flake `system` (Nix build platform)              | `aarch64-darwin`                     | `aarch64-linux`             | `x86_64-darwin`                      | `x86_64-linux`              |
+| Flake `system` (Nix build platform)               | `aarch64-darwin`                     | `aarch64-linux`             | `x86_64-darwin`                      | `x86_64-linux`              |
 | [GitHub Actions Runner][runners] (workflow label) | `macos-latest` (using Apple Silicon) | `ubuntu-latest` (using x86) | `macos-latest` (using Apple Silicon) | `ubuntu-latest` (using x86) |
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ By default, the CI maps the Nix systems to their equivalent GitHub-hosted runner
 
 |                                                   | macOS (Apple Silicon)                | ARM Linux                   | macOS (Intel)                        | x86 Linux                   |
 | ------------------------------------------------- | ------------------------------------ | --------------------------- | ------------------------------------ | --------------------------- |
-| Flake `system:` (Nix build platform) | `aarch64-darwin` | `aarch64-linux` | `x86_64-darwin` | `x86_64-linux`
+| Flake `system:` (Nix build platform)              | `aarch64-darwin`                     | `aarch64-linux`             | `x86_64-darwin`                      | `x86_64-linux`              |
 | [GitHub Actions Runner][runners] (workflow label) | `macos-latest` (using Apple Silicon) | `ubuntu-latest` (using x86) | `macos-latest` (using Apple Silicon) | `ubuntu-latest` (using x86) |
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -97,10 +97,27 @@ ERROR magic_nix_cache: FlakeHub cache initialization failed: FlakeHub cache erro
 
 ### Advanced usage
 
-#### Custom runner types
+#### GitHub Actions Runners
 
-The default runner map uses `ubuntu-latest` for x86 Linux and `macos-latest` for macOS.
-Take advantage of [larger GitHub runners][runners] by providing a custom runner map:
+##### Standard & larger runners
+
+By default, the CI maps the Nix systems to their equivalent GitHub-hosted runners:
+
+|  | macOS (Apple Silicon) | ARM Linux | macOS (Intel) | x86 Linux |
+|---|---|---|---|---|
+| Flake `system:` (Nix build platform) | `aarch64-darwin` | `aarch64-linux` | `x86_64-darwin` | `x86_64-linux` |
+| [GitHub Actions Runner][runners] (workflow label) | `macos-latest` (using Apple Silicon) | `ubuntu-latest` (using x86) | `macos-latest` (using Apple Silicon) | `ubuntu-latest` (using x86) |
+
+> [!INFO]
+> There is also a [standard ARM Linux runner][runners-linux-arm] `ubuntu-24.04-arm`, currently in public preview and only supported on public repositories.
+> To use it, supply your own runner map as shown below.
+> To use ARM Linux runners on private repositories, you need a non-standard runners, as shown below.
+
+##### Non-Standard runners
+
+You can also use several types of non-standard runners by providing a custom runner map.
+
+For example, this runner-map enables the [larger GitHub runners for macOS][runners-large-macos]:
 
 ```yaml
 jobs:
@@ -113,12 +130,30 @@ jobs:
       runner-map: |
         {
           "aarch64-darwin": "macos-latest-xlarge",
-          "aarch64-linux": "UbuntuLatest32Cores128GArm",
-          "i686-linux": "UbuntuLatest32Cores128G",
-          "x86_64-darwin": "macos-latest-xlarge",
-          "x86_64-linux": "UbuntuLatest32Cores128G"
+          "x86_64-darwin": "macos-latest-large"
         }
 ```
+
+> [!TIP]
+> Using `macos-latest-large` is currently the only way to run *current* macOS on Intel architecture.
+
+The other two types of runners are those provisioned on your own infrastructure, and [larger Ubuntu (not macOS) runners][runners-large] with bespoke specs (for example, 64 CPUs, 128GB RAM) hosted by GitHub.
+Confusingly, GitHub sometimes refers to both of these as "self-hosted" runners.
+
+> [!IMPORTANT]
+> Shared workflows such as the one used in this repo [can only access][workflow-access] non-standard runners if the workflow repo (this one) is owned by the same organisation (`DeterminateSystems`) or user.
+> To use this repo with non-standard runners if you are not `DeterminateSystems`, fork the repository and replace the upstream workflow with your fork.
+>
+> ```diff
+> jobs:
+>  DeterminateCI:
+> - uses: DeterminateSystems/ci/.github/workflows/workflow.yml@main
+> + uses: $YOURORG/ci/.github/workflows/workflow.yml@main
+> ```
+>
+> Replace `$YOURORG` with your own organisation or user.
+>
+> This limitation does not apply to larger macOS runners hosted by GitHub.
 
 #### Private SSH keys
 
@@ -150,7 +185,11 @@ This workflow uses a collection of GitHub Actions by Determinate Systems, all of
 [privacy]: https://determinate.systems/policies/privacy
 [private-flakes]: https://docs.determinate.systems/flakehub/private-flakes
 [publishing]: https://docs.determinate.systems/flakehub/publishing
-[runners]: https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners
+[runners]: https://docs.github.com/en/actions/using-github-hosted-runners
+[runners-large]: https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners/about-larger-runners
+[runners-large-macos]: https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners/about-larger-runners#about-macos-larger-runners
+[runners-linux-arm]: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/
 [signup]: https://flakehub.com/signup
 [tos]: https://determinate.systems/policies/terms-of-service
 [visibility]: https://docs.determinate.systems/flakehub/concepts/visibility
+[workflow-access]: https://docs.github.com/en/actions/sharing-automations/reusing-workflows#using-self-hosted-runners


### PR DESCRIPTION
A user on Discord reported running into two related limitations:

1. the linux arm runner only works in public repos (I had missed this limitation in https://github.com/DeterminateSystems/ci/pull/17).
1. the shared workflow in this repo cannot access non-standard runners (~ "self-hosted runners"), including the non-standard ARM Linux runners.

To resolve this friction point, this PR:

1. reverts https://github.com/DeterminateSystems/ci/pull/17; the linux arm runner default, while in public-repo preview, seems to cause more trouble than it's worth, especially for new users.
   Unfortunately, a conditional on `github.event.public` doesn't work without some major hacking in the user's `*.yml`, which seems definitely not worth it.
1. explains in more detail what CPU arch the default runners use
1. explains what to do if you want to use the shared workflow using a non-standard runner (fork!)
1. explain around some inconsistency/confusion in GH docs ("self-hosted", large-mac ...).
   This is a bit awkward, since it risks duplicating GH docs, and I've logged [my feedback](https://github.com/orgs/community/discussions/154405) with GitHub -- but it'll probably remain confusing for some time, so here we are anyway ...