### PR TITLE
Use determinate param consistently

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -81,7 +81,7 @@ jobs:
       # - uses: Determinatesystems/flake-checker-action@main
       - uses: DeterminateSystems/nix-installer-action@main
         with:
-          flakehub: true
+          determinate: true
       - uses: DeterminateSystems/flakehub-cache-action@main
       - uses: webfactory/ssh-agent@v0.9.0
         if: ${{ inputs.enable-ssh-agent }}
@@ -148,7 +148,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
         if: ${{ !github.repository.fork && inputs.visibility != '' && (github.ref == format('refs/heads/{0}', inputs.default-branch) || startsWith(github.ref, 'refs/tags/')) }}
         with:
-          flakehub: true
+          determinate: true
       - uses: DeterminateSystems/flakehub-cache-action@main
         if: ${{ !github.repository.fork && inputs.visibility != '' && (github.ref == format('refs/heads/{0}', inputs.default-branch) || startsWith(github.ref, 'refs/tags/')) }}
       - uses: "DeterminateSystems/flakehub-push@main"


### PR DESCRIPTION
The `flakehub` param for the nix-installer-action is now deprecated in favor of `determinate`.
