### PR TITLE
Allow specifying a flake-iter flakeref

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -108,9 +108,10 @@ jobs:
         id: inventory
         env:
           FLAKE_ITER_RUNNER_MAP: ${{ toJson(fromJson(inputs.runner-map)) }}
+          FLAKE_ITER_FLAKEREF: ${{ inputs.flake-iter-flakeref }}
         working-directory: ${{ inputs.directory }}
         run: |
-          nix run "https://flakehub.com/f/DeterminateSystems/flake-iter/*" -- systems
+          nix run "$FLAKE_ITER_FLAKEREF" -- systems
   build:
     runs-on: ${{ matrix.systems.runner }}
     needs: inventory

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -30,6 +30,12 @@ on:
         required: false
         default: true
         type: boolean
+      flake-iter-flakeref:
+        description: |
+          Flake reference to use for the flake-iter process. Useful for pinning to specific versions should standards require it. Defaults to the latest release available on FlakeHub.
+        type: string
+        required: false
+        default: https://flakehub.com/f/DeterminateSystems/flake-iter/*
       runner-map:
         description: |
           A custom mapping of [Nix system types](https://zero-to-nix.com/concepts/system-specificity) to desired Actions runners
@@ -130,8 +136,9 @@ jobs:
       - name: Build for ${{ matrix.systems.nix-system }}
         env:
           FLAKE_ITER_NIX_SYSTEM: ${{ matrix.systems.nix-system }}
+          FLAKE_ITER_FLAKEREF: ${{ inputs.flake-iter-flakeref }}
         working-directory: ${{ inputs.directory }}
-        run: nix run 'https://flakehub.com/f/DeterminateSystems/flake-iter/*' -- --verbose build
+        run: nix run "$FLAKE_ITER_FLAKEREF" -- --verbose build
 
   success:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR allows users of this workflow to change the `flake-iter` reference being run. This allows users to, for example, pin to a known-good version on FlakeHub or test a branch before submitting a PR.