### PR TITLE
Pin tools using flake.nix

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,6 @@
 
 Please format all files before committing:
 
-    nix run nixpkgs#nodePackages.prettier -- --write .
+    nix develop -c prettier -- --write .
 
 -->

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,8 +17,8 @@ jobs:
         with:
           determinate: true
       - uses: DeterminateSystems/flakehub-cache-action@main
-      - run: nix run nixpkgs#action-validator -- -v ./.github/workflows/workflow.yml
-      - run: nix run nixpkgs#nodePackages.prettier -- --check .
+      - run: nix develop -c action-validator -v ./.github/workflows/workflow.yml
+      - run: nix develop -c prettier --check .
 
   DeterminateCI:
     uses: ./.github/workflows/workflow.yml

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": false
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,40 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1744868846,
+        "narHash": "sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs=",
+        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
+        "revCount": 785333,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.785333%2Brev-ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c/01965c00-a987-7897-9240-abc0268d7590/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/DeterminateSystems/nixpkgs-weekly/%2A"
+      }
+    },
+    "nixpkgs-old": {
+      "locked": {
+        "lastModified": 1745279238,
+        "narHash": "sha256-AQ7M9wTa/Pa/kK5pcGTgX/DGqMHyzsyINfN7ktsI7Fo=",
+        "rev": "9684b53175fc6c09581e94cc85f05ab77464c7e3",
+        "revCount": 717196,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.717196%2Brev-9684b53175fc6c09581e94cc85f05ab77464c7e3/019660c5-eae1-7a61-9902-4417eac98039/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.2411.717196"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-old": "nixpkgs-old"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,44 @@
+{
+  inputs = {
+    nixpkgs.url = "https://flakehub.com/f/DeterminateSystems/nixpkgs-weekly/*";
+
+    # For action-validator, which is broken with new rust versions
+    nixpkgs-old.url = "https://flakehub.com/f/NixOS/nixpkgs/0.2411.717196";
+  };
+
+  outputs =
+    { nixpkgs, nixpkgs-old, ... }:
+    let
+      inherit (nixpkgs) lib;
+
+      systems = [
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-linux"
+        "x86_64-darwin"
+      ];
+
+      forEachSystem =
+        f:
+        lib.genAttrs systems (
+          system:
+          let
+            pkgs = nixpkgs.legacyPackages.${system};
+            pkgs-old = nixpkgs-old.legacyPackages.${system};
+          in
+          f { inherit pkgs pkgs-old; }
+        );
+    in
+    {
+
+      devShells = forEachSystem ({ pkgs, pkgs-old }: {
+        default = pkgs.mkShellNoCC {
+          buildInputs = [
+            pkgs.nodePackages.prettier
+
+            pkgs-old.action-validator
+          ];
+        };
+      });
+    };
+}


### PR DESCRIPTION
This PR adds a flake.nix in order to pin tools in CI. This does mean that we'll need to do flake input updates, but at least we won't be subject to random breakages at inconvenient times.