### PR TITLE
fix(runner-map): use ubuntu-24.04 arm image for aarch64-linux

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -47,7 +47,7 @@ on:
             "x86_64-darwin": "macos-latest",
             "x86_64-linux": "ubuntu-latest",
             "i686-linux": "ubuntu-latest",
-            "aarch64-linux": "ubuntu-latest"
+            "aarch64-linux": "ubuntu-24.04-arm"
           }
     outputs:
       flake_name:


### PR DESCRIPTION
<!--

Please format all files before committing:

    nix develop -c prettier -- --write .

-->
The default options run aarch64-linux jobs on an x86_64-linux runner which fails.
