### PR TITLE
Add extra-nix-conf

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -47,6 +47,12 @@ on:
             "x86_64-linux": "ubuntu-latest",
             "aarch64-linux": "ubuntu-24.04-arm"
           }
+      extra-nix-conf:
+        description: |
+          Extra Nix configuration passed to Determinate Nix
+        required: false
+        type: string
+        default: ""
     outputs:
       flake_name:
         value: ${{ jobs.success.outputs.flake_name }}
@@ -126,6 +132,7 @@ jobs:
         with:
           extra-conf: |
             extra-experimental-features = provenance
+            ${{ inputs.extra-nix-conf }}
       - uses: DeterminateSystems/flakehub-cache-action@main
       - uses: webfactory/ssh-agent@v0.9.0
         if: ${{ inputs.enable-ssh-agent }}

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ You'll see something like this when your workflow has run successfully:
 | `directory`        | The root directory of your flake.                                                                                                                     | `.`                                                                                                       |
 | `fail-fast`        | Whether to cancel all in-progress jobs if any matrix job fails                                                                                        | `true`                                                                                                    |
 | `runner-map`       | A custom mapping of [Nix system types][nix-system] to desired Actions runners                                                                         | `{ "aarch64-darwin": "macos-latest", "x86_64-linux": "ubuntu-latest", "aarch64-linux": "ubuntu-latest" }` |
+| `extra-nix-conf`   | Extra Nix configuration to pass to Determinate Nix                                                                                                    |                                                                                                           |
 
 ## Example configurations
 


### PR DESCRIPTION
<!--

Please format all files before committing:

    nix develop -c prettier -- --write .

-->

Makes it easy to configure anything extra

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new `extra-nix-conf` workflow input to allow passing additional Nix configuration during builds.

* **Documentation**
  * Updated README with documentation for the new `extra-nix-conf` configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->