### PR TITLE
Provide GitHub Actions pinning and fix a bug

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: DeterminateSystems/*
+    commit-message:
+      prefix: ci

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,11 +12,15 @@ jobs:
       contents: read
     steps:
       - name: git checkout
-        uses: actions/checkout@v4
-      - uses: DeterminateSystems/determinate-nix-action@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: DeterminateSystems/determinate-nix-action@9adf02b41cfdac2632e1c16f0480ff5bf3b05dd6 # v3.21.1
       - uses: DeterminateSystems/flakehub-cache-action@main
       - run: nix develop -c action-validator -v ./.github/workflows/workflow.yml
       - run: nix develop -c prettier --check .
+      - name: Check GitHub Actions compliance
+        run: nix develop -c zizmor .github
 
   DeterminateCI:
     uses: ./.github/workflows/workflow.yml

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,9 +17,7 @@ jobs:
           persist-credentials: false
       - uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
-      - name: Validate Action
-        run: nix develop -c action-validator -v ./.github/workflows/workflow.yml
-      - name: Check GitHub Actions expressions
+      - name: Validate GitHub Actions workflows
         run: nix develop -c actionlint
       - name: Check syntax
         run: nix develop -c prettier --check .

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: DeterminateSystems/flakehub-cache-action@main
       - name: Validate Action
         run: nix develop -c action-validator -v ./.github/workflows/workflow.yml
+      - name: Check GitHub Actions expressions
+        run: nix develop -c actionlint
       - name: Check syntax
         run: nix develop -c prettier --check .
       - name: Check GitHub Actions security compliance

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,9 +17,11 @@ jobs:
           persist-credentials: false
       - uses: DeterminateSystems/determinate-nix-action@9adf02b41cfdac2632e1c16f0480ff5bf3b05dd6 # v3.21.1
       - uses: DeterminateSystems/flakehub-cache-action@main
-      - run: nix develop -c action-validator -v ./.github/workflows/workflow.yml
-      - run: nix develop -c prettier --check .
-      - name: Check GitHub Actions compliance
+      - name: Validate Action
+        run: nix develop -c action-validator -v ./.github/workflows/workflow.yml
+      - name: Check syntax
+        run: nix develop -c prettier --check .
+      - name: Check GitHub Actions security compliance
         run: nix develop -c zizmor .github
 
   DeterminateCI:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -97,12 +97,14 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       # disabled pending strategy discussion on exposing tunables
       # - uses: Determinatesystems/flake-checker-action@main
-      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: DeterminateSystems/determinate-nix-action@9adf02b41cfdac2632e1c16f0480ff5bf3b05dd6 # v3.21.1
       - uses: DeterminateSystems/flakehub-cache-action@main
-      - uses: webfactory/ssh-agent@v0.9.0
+      - uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         if: ${{ inputs.enable-ssh-agent }}
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
@@ -127,14 +129,16 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: DeterminateSystems/determinate-nix-action@9adf02b41cfdac2632e1c16f0480ff5bf3b05dd6 # v3.21.1
         with:
           extra-conf: |
             extra-experimental-features = provenance
             ${{ inputs.extra-nix-conf }}
       - uses: DeterminateSystems/flakehub-cache-action@main
-      - uses: webfactory/ssh-agent@v0.9.0
+      - uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         if: ${{ inputs.enable-ssh-agent }}
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
@@ -166,9 +170,11 @@ jobs:
         if: |
           contains(needs.*.result, 'failure') ||
           contains(needs.*.result, 'cancelled')
-      - uses: actions/checkout@main
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         if: ${{ !github.repository.fork && inputs.visibility != '' && (github.ref == format('refs/heads/{0}', inputs.default-branch) || startsWith(github.ref, 'refs/tags/')) }}
-      - uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          persist-credentials: false
+      - uses: DeterminateSystems/determinate-nix-action@9adf02b41cfdac2632e1c16f0480ff5bf3b05dd6 # v3.21.1
         if: ${{ !github.repository.fork && inputs.visibility != '' && (github.ref == format('refs/heads/{0}', inputs.default-branch) || startsWith(github.ref, 'refs/tags/')) }}
       - uses: DeterminateSystems/flakehub-cache-action@main
         if: ${{ !github.repository.fork && inputs.visibility != '' && (github.ref == format('refs/heads/{0}', inputs.default-branch) || startsWith(github.ref, 'refs/tags/')) }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -171,15 +171,15 @@ jobs:
           contains(needs.*.result, 'failure') ||
           contains(needs.*.result, 'cancelled')
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: ${{ !github.repository.fork && inputs.visibility != '' && (github.ref == format('refs/heads/{0}', inputs.default-branch) || startsWith(github.ref, 'refs/tags/')) }}
+        if: ${{ !github.event.repository.fork && inputs.visibility != '' && (github.ref == format('refs/heads/{0}', inputs.default-branch) || startsWith(github.ref, 'refs/tags/')) }}
         with:
           persist-credentials: false
       - uses: DeterminateSystems/determinate-nix-action@main
-        if: ${{ !github.repository.fork && inputs.visibility != '' && (github.ref == format('refs/heads/{0}', inputs.default-branch) || startsWith(github.ref, 'refs/tags/')) }}
+        if: ${{ !github.event.repository.fork && inputs.visibility != '' && (github.ref == format('refs/heads/{0}', inputs.default-branch) || startsWith(github.ref, 'refs/tags/')) }}
       - uses: DeterminateSystems/flakehub-cache-action@main
-        if: ${{ !github.repository.fork && inputs.visibility != '' && (github.ref == format('refs/heads/{0}', inputs.default-branch) || startsWith(github.ref, 'refs/tags/')) }}
+        if: ${{ !github.event.repository.fork && inputs.visibility != '' && (github.ref == format('refs/heads/{0}', inputs.default-branch) || startsWith(github.ref, 'refs/tags/')) }}
       - uses: DeterminateSystems/flakehub-push@main
-        if: ${{ !github.repository.fork && inputs.visibility != '' && (github.ref == format('refs/heads/{0}', inputs.default-branch) || startsWith(github.ref, 'refs/tags/')) }}
+        if: ${{ !github.event.repository.fork && inputs.visibility != '' && (github.ref == format('refs/heads/{0}', inputs.default-branch) || startsWith(github.ref, 'refs/tags/')) }}
         id: publish
         with:
           rolling: ${{ github.ref == format('refs/heads/{0}', inputs.default-branch) }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        DeterminateSystems/*: ref-pin

--- a/flake.lock
+++ b/flake.lock
@@ -2,36 +2,21 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744868846,
-        "narHash": "sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs=",
-        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
-        "revCount": 785333,
+        "lastModified": 1780930886,
+        "narHash": "sha256-rppURzHviaQN131F+nLiLdGfcb0uCd9gGP0E5+iw9MI=",
+        "rev": "8c3cede7ddc26bd659d2d383b5610efbd2c7a16e",
+        "revCount": 1012902,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.785333%2Brev-ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c/01965c00-a987-7897-9240-abc0268d7590/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.1012902%2Brev-8c3cede7ddc26bd659d2d383b5610efbd2c7a16e/019eab22-bd1e-7e40-b919-277db893c789/source.tar.gz"
       },
       "original": {
         "type": "tarball",
         "url": "https://flakehub.com/f/DeterminateSystems/nixpkgs-weekly/%2A"
       }
     },
-    "nixpkgs-old": {
-      "locked": {
-        "lastModified": 1745279238,
-        "narHash": "sha256-AQ7M9wTa/Pa/kK5pcGTgX/DGqMHyzsyINfN7ktsI7Fo=",
-        "rev": "9684b53175fc6c09581e94cc85f05ab77464c7e3",
-        "revCount": 717196,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.717196%2Brev-9684b53175fc6c09581e94cc85f05ab77464c7e3/019660c5-eae1-7a61-9902-4417eac98039/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.2411.717196"
-      }
-    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-old": "nixpkgs-old"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
           default = pkgs.mkShellNoCC {
             packages = with pkgs; [
               action-validator
+              actionlint
               prettier
               zizmor
             ];

--- a/flake.nix
+++ b/flake.nix
@@ -1,15 +1,10 @@
 {
-  inputs = {
-    nixpkgs.url = "https://flakehub.com/f/DeterminateSystems/nixpkgs-weekly/*";
-
-    # For action-validator, which is broken with new rust versions
-    nixpkgs-old.url = "https://flakehub.com/f/NixOS/nixpkgs/0.2411.717196";
-  };
+  inputs.nixpkgs.url = "https://flakehub.com/f/DeterminateSystems/nixpkgs-weekly/*";
 
   outputs =
-    { nixpkgs, nixpkgs-old, ... }:
+    { self, ... }@inputs:
     let
-      inherit (nixpkgs) lib;
+      inherit (inputs.nixpkgs) lib;
 
       systems = [
         "aarch64-linux"
@@ -20,27 +15,23 @@
       forEachSystem =
         f:
         lib.genAttrs systems (
-          system:
-          let
-            pkgs = nixpkgs.legacyPackages.${system};
-            pkgs-old = nixpkgs-old.legacyPackages.${system};
-          in
-          f { inherit pkgs pkgs-old; }
+          system: f { pkgs = import inputs.nixpkgs { inherit system; }; }
         );
     in
     {
-
       devShells = forEachSystem (
-        { pkgs, pkgs-old }:
+        { pkgs }:
         {
           default = pkgs.mkShellNoCC {
-            buildInputs = [
-              pkgs.nodePackages.prettier
-
-              pkgs-old.action-validator
+            packages = with pkgs; [
+              action-validator
+              prettier
+              zizmor
             ];
           };
         }
       );
+
+      formatter = forEachSystem ({ pkgs }: pkgs.nixfmt);
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,6 @@
         {
           default = pkgs.mkShellNoCC {
             packages = with pkgs; [
-              action-validator
               actionlint
               prettier
               zizmor


### PR DESCRIPTION
Pins GitHub Actions to commit SHAs, adds Dependabot to keep those pins current, and adds `zizmor` to check for unpinned actions and `actionLint` to catch thorny bugs going forward.

## Fixing the fork guard

The publish steps were gated on `!github.repository.fork`. But `github.repository` is the `owner/repo` **string**, so `.fork` was always null and `!null` always true: the guard never blocked anything. All four steps now use `github.event.repository.fork`.

It guards pushes, not PRs. On a `pull_request` from a fork, `github.event.repository` is the *base* repo, so `.fork` is false there too — fork PRs are stopped by the `github.ref` check on the same line. What's newly covered is a push to a fork's own `main`.

## Why actionlint, and why `action-validator` is gone

Neither of our existing checkers catches the bug above. `action-validator` validates workflow YAML against the SchemaStore JSON schema — it knows `if:` must be a string, but can't reason about what's inside `${{ }}`, and exits clean on the broken file. `zizmor` covers security posture, not expression correctness.

actionlint type-checks expression contents against the real GitHub context types, and flags the broken guard on all four lines:

```
receiver of object dereference "fork" must be type of object but got "string" [expression]
```

It also runs shellcheck over `run:` blocks, pyflakes over inline Python, and validates action input/output names against each action's real metadata.

**`action-validator` is dropped, not kept alongside.** actionlint fully covers its remit. Given a workflow with a misspelled `stpes:`, a missing `runs-on:`, and a string where a number belongs, actionlint reports all three with clearer messages, e.g.:

```
unexpected key "stpes" for "job" section. expected one of "concurrency", ... [syntax-check]
"runs-on" section is missing in job "b" [syntax-check]
```

`action-validator` reports the same file by dumping a raw Rust `ValidationState` struct, and finds nothing actionlint misses.

**`zizmor` stays.** It and actionlint overlap on exactly one audit — script injection — and otherwise cover different ground. zizmor flags `unpinned-uses` and `artipacked`, which actionlint is silent on; supply-chain posture isn't its job, and expression typing isn't zizmor's. That leaves two tools split cleanly between correctness and security.

actionlint runs clean over both workflows today, with no shellcheck suppressions needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added weekly automated monitoring and grouped updates for GitHub Actions dependencies.
  * Improved workflow security by disabling credential persistence and pinning action references.
  * Added automated security checks for unpinned workflow actions.
  * Simplified development environment setup with a consolidated package set and updated formatting tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


